### PR TITLE
Remove unused file-based serialization code

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ ummon query "select functions where file_path like 'src/auth/%'" --no-llm
 ummon assist "implement a user registration function"
 
 # Start an MCP server (Model Context Protocol) for AI agent interaction
-ummon serve                      # Use stdin/stdout (default)
-ummon serve --transport http     # Use HTTP server (requires feature flag)
+ummon serve                      # MCP server uses stdin/stdout for communication
 ```
 
 ## MCP Server
@@ -106,10 +105,7 @@ Ummon includes a Model Context Protocol (MCP) server that allows AI agents to in
 
 - `search_code`: Search for code entities using a natural language query
 - `get_entity`: Get detailed information about a specific entity
-
-### Available Resources:
-
-- `knowledge_graph.json`: The full knowledge graph in JSON format
+- `debug_graph`: Get information about the knowledge graph structure
 
 ### Example MCP Usage:
 

--- a/src/graph/entity.rs
+++ b/src/graph/entity.rs
@@ -3,17 +3,22 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 /// Position in a source file
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Position {
+    #[serde(default)]
     pub line: usize,
+    #[serde(default)]
     pub column: usize,
+    #[serde(default)]
     pub offset: usize,
 }
 
 /// Location range in a source file
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Location {
+    #[serde(default)]
     pub start: Position,
+    #[serde(default)]
     pub end: Position,
 }
 
@@ -28,11 +33,20 @@ pub enum Visibility {
     Default,
 }
 
+impl std::default::Default for Visibility {
+    fn default() -> Self {
+        Visibility::Default
+    }
+}
+
 /// Parameter in a function or method
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Parameter {
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub type_annotation: Option<String>,
+    #[serde(default)]
     pub default_value: Option<String>,
 }
 
@@ -201,14 +215,21 @@ pub struct FunctionEntity {
 }
 
 /// Serializable data for function entities
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Default)]
 pub struct FunctionEntityData {
+    #[serde(default)]
     pub parameters: Vec<Parameter>,
+    #[serde(default)]
     pub return_type: Option<String>,
+    #[serde(default)]
     pub visibility: Visibility,
+    #[serde(default)]
     pub is_async: bool,
+    #[serde(default)]
     pub is_static: bool,
+    #[serde(default)]
     pub is_constructor: bool,
+    #[serde(default)]
     pub is_abstract: bool,
 }
 
@@ -267,12 +288,17 @@ pub struct TypeEntity {
 }
 
 /// Serializable data for type entities
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Default)]
 pub struct TypeEntityData {
+    #[serde(default)]
     pub fields: Vec<EntityId>,
+    #[serde(default)]
     pub methods: Vec<EntityId>,
+    #[serde(default)]
     pub supertypes: Vec<EntityId>,
+    #[serde(default)]
     pub visibility: Visibility,
+    #[serde(default)]
     pub is_abstract: bool,
 }
 
@@ -327,10 +353,13 @@ pub struct ModuleEntity {
 }
 
 /// Serializable data for module entities
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Default)]
 pub struct ModuleEntityData {
+    #[serde(default)]
     pub path: String,
+    #[serde(default)]
     pub children: Vec<EntityId>,
+    #[serde(default)]
     pub imports: Vec<String>,
 }
 
@@ -384,11 +413,15 @@ pub struct VariableEntity {
 }
 
 /// Serializable data for variable entities
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Default)]
 pub struct VariableEntityData {
+    #[serde(default)]
     pub type_annotation: Option<String>,
+    #[serde(default)]
     pub visibility: Visibility,
+    #[serde(default)]
     pub is_const: bool,
+    #[serde(default)]
     pub is_static: bool,
 }
 
@@ -442,11 +475,18 @@ pub struct DomainConceptEntity {
 }
 
 /// Serializable data for domain concept entities
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Default)]
 pub struct DomainConceptEntityData {
+    #[serde(default)]
     pub attributes: Vec<String>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default = "default_confidence")]
     pub confidence: f32,
+}
+
+fn default_confidence() -> f32 {
+    0.5
 }
 
 impl Entity for DomainConceptEntity {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod commands;
+mod db;
 mod graph;
 mod mcp_core;
 mod mcp_server;

--- a/src/mcp_core/types.rs
+++ b/src/mcp_core/types.rs
@@ -60,12 +60,6 @@ impl CapabilitiesBuilder {
         self
     }
 
-    pub fn with_resources(mut self, read: bool, write: bool) -> Self {
-        self.resources_read = read;
-        self.resources_write = write;
-        self
-    }
-
     pub fn build(self) -> ServerCapabilities {
         ServerCapabilities {
             tools: self.tools,
@@ -101,17 +95,6 @@ pub struct Resource {
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub writeable: Option<bool>,
-}
-
-impl Resource {
-    pub fn new(uri: String, name: String, description: String, writeable: Option<bool>) -> Self {
-        Self {
-            uri,
-            name,
-            description,
-            writeable,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/mcp_server/router.rs
+++ b/src/mcp_server/router.rs
@@ -1079,10 +1079,7 @@ impl Router for UmmonRouter {
     }
 
     fn capabilities(&self) -> ServerCapabilities {
-        CapabilitiesBuilder::new()
-            .with_tools(true)
-            .with_resources(true, false)
-            .build()
+        CapabilitiesBuilder::new().with_tools(true).build() // No resources supported
     }
 
     fn list_tools(&self) -> Vec<Tool> {
@@ -1268,12 +1265,7 @@ impl Router for UmmonRouter {
     }
 
     fn list_resources(&self) -> Vec<Resource> {
-        vec![Resource::new(
-            "knowledge_graph.json".to_string(),
-            "Knowledge Graph".to_string(),
-            "The full knowledge graph in JSON format".to_string(),
-            Some(false),
-        )]
+        vec![] // No resources exposed directly
     }
 
     fn read_resource(
@@ -1281,24 +1273,9 @@ impl Router for UmmonRouter {
         uri: &str,
     ) -> Pin<Box<dyn Future<Output = Result<String, ResourceError>> + Send + 'static>> {
         let uri = uri.to_string();
-        let router = self.clone();
 
-        Box::pin(async move {
-            match uri.as_str() {
-                "knowledge_graph.json" => {
-                    let json =
-                        serde_json::to_string_pretty(&*router.knowledge_graph).map_err(|e| {
-                            ResourceError::Internal(format!(
-                                "Failed to serialize knowledge graph: {}",
-                                e
-                            ))
-                        })?;
-
-                    Ok(json)
-                }
-                _ => Err(ResourceError::NotFound(uri)),
-            }
-        })
+        // No resources are available
+        Box::pin(async move { Err(ResourceError::NotFound(uri)) })
     }
 }
 


### PR DESCRIPTION
## Summary
- Complete the transition from file-based knowledge graph storage to SQLite database
- Remove all unused serialization code and file-based methods that are no longer needed
- Simplify and clean up database schema initialization

## Test plan
- Verify all commands (index, serve, query, assist) work correctly with the database backend
- Ensure no regressions in functionality when loading/saving knowledge graph data

🤖 Generated with [Claude Code](https://claude.ai/code)