### PR TITLE
Remove mock LLM provider and improve error handling for missing API keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,15 @@ cargo fmt
 ## Test Structure
 Tests have been set up as inline modules within each source file using Rust's `#[cfg(test)]` attribute.
 
+## Test Principles
+- **CRITICAL**: When a test fails, NEVER change the test assertions to match incorrect implementation. Always:
+  1. Verify that the test assertions represent the correct expected behavior
+  2. If the test is correct, fix the implementation to match the expected behavior
+  3. Only modify test assertions if the test itself is incorrect (not to match buggy code)
+- Tests should be independent and not rely on external state or environment variables
+- Mock external dependencies rather than making real API calls
+- Each test should focus on a specific behavior or feature
+
 
 ## Code Style Guidelines
 - **Imports**: Group standard library imports first, followed by external crates, then local modules
@@ -91,3 +100,5 @@ Tests have been set up as inline modules within each source file using Rust's `#
 - **Sections**: Use comment blocks `// ---- SECTION NAME ----` to separate logical sections within large files
 - **Reasoning**: Include rationale for non-obvious implementation choices
 - **Minimalism**: Avoid adding comments for straightforward operations or self-explanatory code
+- **IMPORTANT**: Do NOT add inline comments that merely restate what the code already shows (e.g., "// Iterate through users" for a loop over users)
+- **CRITICAL**: Never use redundant or descriptive inline comments that explain the obvious function of the code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2260,7 @@ dependencies = [
  "env_logger",
  "futures",
  "ignore",
+ "indoc",
  "log",
  "once_cell",
  "pest",

--- a/src/parser/language_support/java.rs
+++ b/src/parser/language_support/java.rs
@@ -1,5 +1,4 @@
 use super::*;
-use indoc::indoc;
 use tree_sitter::{Node, Parser};
 
 pub struct JavaParser {
@@ -514,10 +513,7 @@ impl JavaParser {
 
 impl LanguageParser for JavaParser {
     fn can_handle(&self, file_path: &Path) -> bool {
-        file_path
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .map_or(false, |ext| ext == "java")
+        file_path.extension().and_then(|ext| ext.to_str()) == Some("java")
     }
 
     /// Parses Java methods and constructors from source code.
@@ -910,6 +906,7 @@ impl LanguageParser for JavaParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_java_basic_parsing() {

--- a/src/parser/language_support/javascript.rs
+++ b/src/parser/language_support/javascript.rs
@@ -1,6 +1,5 @@
 use super::*;
 use anyhow::Result;
-use indoc::indoc;
 use std::path::Path;
 use tree_sitter::{Node, Parser};
 
@@ -317,7 +316,7 @@ impl LanguageParser for JavaScriptParser {
         file_path
             .extension()
             .and_then(|e| e.to_str())
-            .map_or(false, |ext| matches!(ext, "js" | "jsx" | "ts" | "tsx"))
+            .is_some_and(|ext| matches!(ext, "js" | "jsx" | "ts" | "tsx"))
     }
 
     /// Parses JavaScript functions and methods from the source code.
@@ -561,6 +560,7 @@ impl LanguageParser for JavaScriptParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_parse_function_declaration() -> Result<()> {

--- a/src/parser/language_support/mod.rs
+++ b/src/parser/language_support/mod.rs
@@ -12,6 +12,17 @@ pub mod javascript;
 pub mod python;
 pub mod rust;
 
+/// List of supported source file extensions.
+pub const SUPPORTED_EXTENSIONS: &[&str] = &["rs", "py", "js", "java"];
+
+/// Checks if the given path is a supported source file based on its extension.
+pub fn is_supported_source_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| SUPPORTED_EXTENSIONS.contains(&ext))
+        .unwrap_or(false)
+}
+
 // Legacy structures maintained for backward compatibility
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FunctionDefinition {

--- a/src/parser/language_support/python.rs
+++ b/src/parser/language_support/python.rs
@@ -1,5 +1,4 @@
 use super::*;
-use indoc::indoc;
 use tree_sitter::{Node, Parser};
 
 pub struct PythonParser {
@@ -598,10 +597,7 @@ impl PythonParser {
 
 impl LanguageParser for PythonParser {
     fn can_handle(&self, file_path: &Path) -> bool {
-        file_path
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .map_or(false, |ext| ext == "py")
+        file_path.extension().and_then(|ext| ext.to_str()) == Some("py")
     }
 
     fn parse_types(&mut self, content: &str, file_path: &str) -> Result<Vec<TypeDefinition>> {
@@ -863,6 +859,7 @@ impl LanguageParser for PythonParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_python_function_parameter_extraction() {

--- a/src/parser/language_support/rust.rs
+++ b/src/parser/language_support/rust.rs
@@ -646,10 +646,7 @@ impl LanguageParser for RustParser {
     /// # Returns
     /// * `bool` - True if this parser can handle the file, false otherwise
     fn can_handle(&self, file_path: &Path) -> bool {
-        file_path
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .map_or(false, |ext| ext == "rs")
+        file_path.extension().and_then(|ext| ext.to_str()) == Some("rs")
     }
 
     /// Safely extracts text from source code with bounds checking
@@ -753,7 +750,7 @@ impl LanguageParser for RustParser {
                     .parent()
                     .map(|p| {
                         p.kind() == "declaration_list"
-                            && p.parent().map_or(false, |gp| gp.kind() == "mod_item")
+                            && p.parent().is_some_and(|gp| gp.kind() == "mod_item")
                     })
                     .unwrap_or(false);
 
@@ -825,7 +822,7 @@ impl LanguageParser for RustParser {
         self.traverse_node(root_node, &mut |node| {
             if node.kind() == "function_item" {
                 let is_top_level = node.parent().is_none()
-                    || node.parent().map_or(false, |p| p.kind() == "source_file");
+                    || node.parent().is_some_and(|p| p.kind() == "source_file");
 
                 if is_top_level {
                     if let Some(func) = self.extract_function_details(node, content, file_path) {

--- a/src/query/nl_translator.rs
+++ b/src/query/nl_translator.rs
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     fn test_build_translation_prompt() {
         let config = LlmConfig {
-            provider: LlmProvider::Mock,
+            provider: LlmProvider::OpenAI,
             model: "dummy".to_string(),
             api_key: "dummy".to_string(),
             temperature: 0.0,
@@ -199,7 +199,7 @@ mod tests {
     #[test]
     fn test_extract_query_and_confidence() {
         let config = LlmConfig {
-            provider: LlmProvider::Mock,
+            provider: LlmProvider::OpenAI,
             model: "dummy".to_string(),
             api_key: "dummy".to_string(),
             temperature: 0.0,

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Result};
-use indoc::indoc;
 use pest::{iterators::Pair, Parser};
 use pest_derive::Parser;
 


### PR DESCRIPTION
## Summary
- Removes the  enum variant and all references
- Updates error messages to indicate that LLM extraction is disabled when API keys are missing
- Improves error handling for missing API keys with proper errors
- Fixes code quality issues (map_or usage, unused imports, etc.)

## Test plan
1. Run 
running 103 tests
test graph::entity::tests::test_domain_concept_entity ... ok
test graph::entity::tests::test_base_entity ... ok
test graph::entity::tests::test_entity_id ... ok
test graph::entity::tests::test_entity_type_conversion ... ok
test graph::entity::tests::test_file_path_accessor ... ok
test graph::entity::tests::test_function_entity ... ok
test graph::entity::tests::test_module_entity ... ok
test graph::entity::tests::test_variable_entity ... ok
test graph::entity::tests::test_type_entity ... ok
test graph::knowledge_graph::tests::test_add_entity ... ok
test graph::knowledge_graph::tests::test_add_bidirectional_relationship ... ok
test graph::knowledge_graph::tests::test_add_entity_duplicate ... ok
test graph::knowledge_graph::tests::test_add_relationship ... ok
test graph::knowledge_graph::tests::test_add_relationship_with_nonexistent_entity ... ok
test graph::knowledge_graph::tests::test_domain_concept_relationships ... ok
test graph::knowledge_graph::tests::test_domain_concepts ... ok
test graph::knowledge_graph::tests::test_find_paths ... ok
test graph::knowledge_graph::tests::test_find_paths_complex ... ok
test graph::knowledge_graph::tests::test_get_entities_by_type ... ok
test graph::knowledge_graph::tests::test_get_entities_with_multiple_filters ... ok
test graph::knowledge_graph::tests::test_new_knowledge_graph ... ok
test graph::relationship::tests::test_relationship_creation ... ok
test graph::relationship::tests::test_relationship_generate_id ... ok
test graph::relationship::tests::test_relationship_id_creation ... ok
test graph::relationship::tests::test_relationship_metadata ... ok
test graph::relationship::tests::test_relationship_store ... ok
test graph::relationship::tests::test_relationship_store_empty ... ok
test graph::relationship::tests::test_relationship_store_multiple_relationships ... ok
test graph::relationship::tests::test_relationship_types ... ok
test graph::relationship::tests::test_relationship_weight ... ok
test mcp_server::router::tests::test_debug_graph_tool ... ok
test mcp_server::router::tests::test_explain_architecture_tool ... ok
test mcp_server::router::tests::test_explore_relationships_tool ... ok
test mcp_server::router::tests::test_find_relevant_files_tool ... ok
test mcp_server::router::tests::test_get_entity_tool ... ok
test mcp_server::router::tests::test_search_code_tool ... ok
test mcp_server::router::tests::test_tool_error_handling ... ok
test parser::language_support::java::tests::test_java_basic_parsing ... ok
test parser::language_support::java::tests::test_java_field_extraction ... ok
test parser::language_support::java::tests::test_java_generic_parameters ... ok
test parser::language_support::java::tests::test_java_parser_boundary_conditions ... ok
test parser::language_support::java::tests::test_java_parser_empty_content ... ok
test parser::language_support::java::tests::test_java_parser_invalid_content ... ok
test parser::language_support::javascript::tests::test_javascript_parser_boundary_conditions ... ok
test parser::language_support::javascript::tests::test_javascript_parser_empty_content ... ok
test parser::language_support::javascript::tests::test_javascript_parser_invalid_content ... ok
test parser::language_support::javascript::tests::test_parse_arrow_function ... ok
test parser::language_support::javascript::tests::test_parse_calls ... ok
test parser::language_support::javascript::tests::test_parse_class_method ... ok
test parser::language_support::javascript::tests::test_parse_function_declaration ... ok
test parser::language_support::javascript::tests::test_typescript_generic_parameters ... ok
test parser::language_support::python::tests::test_python_class_field_extraction ... ok
test parser::language_support::python::tests::test_python_function_parameter_extraction ... ok
test parser::language_support::python::tests::test_python_generic_parameters ... ok
test parser::language_support::python::tests::test_python_nested_entities ... ok
test parser::language_support::python::tests::test_python_parser_boundary_conditions ... ok
test parser::language_support::python::tests::test_python_parser_empty_content ... ok
test graph::knowledge_graph::tests::test_large_graph ... ok
test db::tests::test_database_initialization ... ok
test parser::language_support::rust::tests::test_impl_generic_parameters ... ignored
test parser::language_support::rust::tests::test_generic_parameters ... ok
test parser::language_support::python::tests::test_python_parser_invalid_content ... ok
test parser::language_support::rust::tests::test_parse_calls ... ok
test parser::language_support::rust::tests::test_parse_method ... ok
test parser::language_support::rust::tests::test_parse_simple_function ... ok
test parser::language_support::rust::tests::test_nested_entities ... ok
test parser::language_support::rust::tests::test_parse_struct_fields ... ok
test parser::language_support::rust::tests::test_rust_parser_empty_content ... ok
test prompt::domain_extraction::tests::test_build_domain_extraction_prompt ... ok
test prompt::domain_extraction::tests::test_chunk_file ... ok
test db::tests::test_multiple_entities_and_relationships ... ok
test parser::language_support::rust::tests::test_rust_parser_boundary_conditions ... ok
test db::tests::test_save_and_load_entity ... ok
test db::tests::test_transaction_integrity ... ok
test prompt::llm_integration::tests::test_get_endpoint_url ... ok
test prompt::llm_integration::tests::test_get_request_headers ... ok
test prompt::domain_extraction::tests::test_deduplicate_entities ... ok
test prompt::llm_integration::tests::test_llm_config_default ... ok
test prompt::llm_integration::tests::test_prepare_request_body ... ok
test prompt::llm_integration::tests::test_llm_provider_parsing ... ok
test query::executor::tests::test_execute_select_all_functions ... ok
test query::executor::tests::test_execute_traversal_query ... ok
test query::formatter::tests::test_empty_results ... ok
test query::executor::tests::test_execute_traversal_with_condition ... ok
test db::tests::test_save_and_load_relationship ... ok
test parser::language_support::rust::tests::test_rust_parser_invalid_content ... ok
test query::formatter::tests::test_format_text ... ok
test query::formatter::tests::test_format_csv ... ok
test query::formatter::tests::test_format_tree ... ok
test query::formatter::tests::test_format_json ... ok
test query::nl_translator::tests::test_build_translation_prompt ... ok
test query::nl_translator::tests::test_translate_simple_query ... ignored
test query::parser::tests::test_has_attribute_condition ... ok
test query::parser::tests::test_invalid_query ... ok
test query::parser::tests::test_complex_condition ... ok
test query::parser::tests::test_parse_select_query_simple ... ok
test query::nl_translator::tests::test_extract_query_and_confidence ... ok
test query::parser::tests::test_parse_traversal_query ... ok
test query::parser::tests::test_parse_traversal_query_with_condition ... ok
test query::parser::tests::test_parse_select_query_with_condition ... ok
test query::executor::tests::test_execute_select_with_condition ... ok
test query::executor::tests::test_execute_complex_condition ... ok
test db::tests::test_concurrent_saves ... ok

test result: ok. 101 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.13s


running 103 tests
test graph::entity::tests::test_domain_concept_entity ... ok
test graph::entity::tests::test_entity_id ... ok
test graph::entity::tests::test_base_entity ... ok
test graph::entity::tests::test_entity_type_conversion ... ok
test graph::entity::tests::test_file_path_accessor ... ok
test graph::entity::tests::test_function_entity ... ok
test graph::entity::tests::test_module_entity ... ok
test graph::entity::tests::test_type_entity ... ok
test graph::entity::tests::test_variable_entity ... ok
test graph::knowledge_graph::tests::test_add_bidirectional_relationship ... ok
test graph::knowledge_graph::tests::test_add_entity ... ok
test graph::knowledge_graph::tests::test_add_entity_duplicate ... ok
test graph::knowledge_graph::tests::test_add_relationship ... ok
test graph::knowledge_graph::tests::test_add_relationship_with_nonexistent_entity ... ok
test graph::knowledge_graph::tests::test_domain_concept_relationships ... ok
test graph::knowledge_graph::tests::test_domain_concepts ... ok
test graph::knowledge_graph::tests::test_find_paths ... ok
test graph::knowledge_graph::tests::test_get_entities_by_type ... ok
test graph::knowledge_graph::tests::test_find_paths_complex ... ok
test graph::knowledge_graph::tests::test_get_entities_with_multiple_filters ... ok
test graph::knowledge_graph::tests::test_new_knowledge_graph ... ok
test graph::relationship::tests::test_relationship_creation ... ok
test graph::relationship::tests::test_relationship_generate_id ... ok
test graph::relationship::tests::test_relationship_id_creation ... ok
test graph::relationship::tests::test_relationship_metadata ... ok
test graph::relationship::tests::test_relationship_store ... ok
test graph::relationship::tests::test_relationship_store_empty ... ok
test graph::relationship::tests::test_relationship_store_multiple_relationships ... ok
test graph::relationship::tests::test_relationship_types ... ok
test graph::relationship::tests::test_relationship_weight ... ok
test mcp_server::router::tests::test_debug_graph_tool ... ok
test mcp_server::router::tests::test_explain_architecture_tool ... ok
test mcp_server::router::tests::test_explore_relationships_tool ... ok
test mcp_server::router::tests::test_find_relevant_files_tool ... ok
test mcp_server::router::tests::test_get_entity_tool ... ok
test mcp_server::router::tests::test_search_code_tool ... ok
test mcp_server::router::tests::test_tool_error_handling ... ok
test parser::language_support::java::tests::test_java_basic_parsing ... ok
test parser::language_support::java::tests::test_java_field_extraction ... ok
test parser::language_support::java::tests::test_java_generic_parameters ... ok
test parser::language_support::java::tests::test_java_parser_boundary_conditions ... ok
test parser::language_support::java::tests::test_java_parser_empty_content ... ok
test parser::language_support::java::tests::test_java_parser_invalid_content ... ok
test db::tests::test_database_initialization ... ok
test parser::language_support::javascript::tests::test_javascript_parser_empty_content ... ok
test parser::language_support::javascript::tests::test_javascript_parser_boundary_conditions ... ok
test db::tests::test_save_and_load_entity ... ok
test db::tests::test_save_and_load_relationship ... ok
test parser::language_support::javascript::tests::test_parse_arrow_function ... ok
test parser::language_support::javascript::tests::test_javascript_parser_invalid_content ... ok
test parser::language_support::javascript::tests::test_parse_function_declaration ... ok
test db::tests::test_transaction_integrity ... ok
test parser::language_support::javascript::tests::test_parse_class_method ... ok
test parser::language_support::javascript::tests::test_typescript_generic_parameters ... ok
test parser::language_support::javascript::tests::test_parse_calls ... ok
test parser::language_support::python::tests::test_python_class_field_extraction ... ok
test parser::language_support::python::tests::test_python_parser_empty_content ... ok
test parser::language_support::python::tests::test_python_function_parameter_extraction ... ok
test parser::language_support::python::tests::test_python_generic_parameters ... ok
test parser::language_support::rust::tests::test_impl_generic_parameters ... ignored
test parser::language_support::python::tests::test_python_parser_boundary_conditions ... ok
test parser::language_support::python::tests::test_python_nested_entities ... ok
test db::tests::test_multiple_entities_and_relationships ... ok
test parser::language_support::rust::tests::test_parse_method ... ok
test parser::language_support::rust::tests::test_parse_calls ... ok
test parser::language_support::rust::tests::test_generic_parameters ... ok
test parser::language_support::rust::tests::test_parse_simple_function ... ok
test parser::language_support::rust::tests::test_nested_entities ... ok
test parser::language_support::python::tests::test_python_parser_invalid_content ... ok
test parser::language_support::rust::tests::test_rust_parser_empty_content ... ok
test prompt::domain_extraction::tests::test_chunk_file ... ok
test parser::language_support::rust::tests::test_parse_struct_fields ... ok
test parser::language_support::rust::tests::test_rust_parser_boundary_conditions ... ok
test prompt::domain_extraction::tests::test_deduplicate_entities ... ok
test prompt::llm_integration::tests::test_llm_config_default ... ok
test prompt::domain_extraction::tests::test_build_domain_extraction_prompt ... ok
test prompt::llm_integration::tests::test_get_endpoint_url ... ok
test prompt::llm_integration::tests::test_get_request_headers ... ok
test prompt::llm_integration::tests::test_prepare_request_body ... ok
test prompt::llm_integration::tests::test_llm_provider_parsing ... ok
test parser::language_support::rust::tests::test_rust_parser_invalid_content ... ok
test graph::knowledge_graph::tests::test_large_graph ... ok
test query::executor::tests::test_execute_select_all_functions ... ok
test query::formatter::tests::test_empty_results ... ok
test query::formatter::tests::test_format_csv ... ok
test query::executor::tests::test_execute_traversal_query ... ok
test query::executor::tests::test_execute_traversal_with_condition ... ok
test query::formatter::tests::test_format_json ... ok
test query::formatter::tests::test_format_text ... ok
test query::formatter::tests::test_format_tree ... ok
test query::nl_translator::tests::test_translate_simple_query ... ignored
test query::nl_translator::tests::test_build_translation_prompt ... ok
test query::parser::tests::test_has_attribute_condition ... ok
test query::parser::tests::test_complex_condition ... ok
test query::parser::tests::test_parse_select_query_simple ... ok
test query::parser::tests::test_invalid_query ... ok
test query::nl_translator::tests::test_extract_query_and_confidence ... ok
test query::parser::tests::test_parse_traversal_query ... ok
test query::parser::tests::test_parse_select_query_with_condition ... ok
test query::parser::tests::test_parse_traversal_query_with_condition ... ok
test query::executor::tests::test_execute_select_with_condition ... ok
test query::executor::tests::test_execute_complex_condition ... ok
test db::tests::test_concurrent_saves ... ok

test result: ok. 101 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.13s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s to ensure all tests pass
2. Test domain extraction with and without API keys to verify proper error handling
3. Verify natural language queries work with an API key

Fixes #41 (partially - addresses the error handling, full domain extraction improvements to be done separately)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>